### PR TITLE
use boolValue to set usesGCM and gcmSandbox

### DIFF
--- a/src/ios/GCMPushPlugin.m
+++ b/src/ios/GCMPushPlugin.m
@@ -140,8 +140,8 @@
         return;
     }
     self.jsCallback = jsCallback;
-    self.usesGCM = [options objectForKey:@"usesGCM"];
-    self.gcmSandbox = [options objectForKey:@"sandbox"];
+    self.usesGCM = [[options objectForKey:@"usesGCM"] boolValue];
+    self.gcmSandbox = [[options objectForKey:@"sandbox"] boolValue];
     
     [[NSUserDefaults standardUserDefaults] setBool:self.usesGCM forKey:@"usesGCM"];
     [[NSUserDefaults standardUserDefaults] setObject:jsCallback forKey:@"jsCallback"];


### PR DESCRIPTION
When testing push notifications in a production ad-hoc build on iOS, i noticed that the gcmSandbox option was being set to YES even though the javascript was passing false.  

Upon debugging it looks like the return values were NSStrings @"1" or @"0" for true and false, both of which when casted directly to BOOL return YES (since they are both non-nil).   Using boolValue seems to set the value correctly.  

i.e.

```
(BOOL) @"1" = YES
(BOOL) @"0" = YES

[@"1" boolValue] = YES
[@"0" boolValue] = NO
```
